### PR TITLE
Added paper: Scaling up search engine audits: Practical insights for algorithm auditing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ Nowadays, many algorithms (recommendation, scoring, classification) are operated
 
 ## Contents
 - [Papers](#papers)
-- [Related Events](#Related Events)
+- [Related Events](#related-events)
 
 ## Papers
 ### 2022
+- [Scaling up search engine audits: Practical insights for algorithm auditing](https://journals.sagepub.com/doi/10.1177/01655515221093029) - (Journal of Information Science) [(Code)](https://github.com/gesiscss/WebBot) *Audits multiple search engines using simulated browsing behavior with virtual agents.*
 - [A zest of lime: towards architecture-independent model distances](https://openreview.net/pdf?id=OUz_9TiTv9j) - (ICLR) *Measures the distance between two remote models using LIME.*
 - [Active Fairness Auditing](https://proceedings.mlr.press/v162/yan22c/yan22c.pdf) - (ICML) *Studies of query-based auditing algorithms that can estimate the demographic parity of ML models in a query-efficient manner.*
 - [Look at the Variance! Efficient Black-box Explanations with Sobol-based Sensitivity Analysis](https://proceedings.neurips.cc/paper/2021/file/da94cbeff56cfda50785df477941308b-Paper.pdf) - (NeurIPS) *Sobol indices provide an efficient way to capture higher-order interactions between image regions and their contributions to a (black box) neural network’s prediction through the lens of variance.*


### PR DESCRIPTION
I am currently contributing to a web browser extension that enables audits of search engines (Google, DuckDuckGo, Baidu, Yandex,…) using virtual agents to simulate browsing behavior. It would be great if you could add it to the list!

This pull request also fixes the link to #related-events in the content section of the readme.